### PR TITLE
DeathKnell should NOT be used in production code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 DeathKnell
 ==========
 
-A class that allows a final callback when fatal errors (SEGV, SIGKILL, etc) are received
+A unit test helper class that allows a final callback when fatal errors (SEGV, SIGKILL, etc) are received.  This is for **unit testing of death scenarios**. It should **not** currently be used in production code. 


### PR DESCRIPTION
Death::WasKilled() will always return true in production code UNLESS ```Death::SetupExitHandler()``` was called . If that function is called then the normal shut down sequence for g2log-dev is hijacked. This however leads to thread and process unsafe shutdown and the potential for continuos **death** races. 

In summary:  DeathKnell should only be used for unit testing code.